### PR TITLE
Sorting change

### DIFF
--- a/fields/field.uniquecheckbox.php
+++ b/fields/field.uniquecheckbox.php
@@ -179,7 +179,7 @@
 					`tbl_entries_data_{$field_id}` AS ed
 					ON (e.id = ed.entry_id)
 			";
-			$sort = 'ORDER BY ' . (strtolower($order) == 'random' ? 'RAND()' : "ed.value {$order}");
+			$sort = 'ORDER BY ' . (strtolower($order) == 'random' ? 'RAND()' : "ed.order {$order}");
 		}
 		
 		public function buildDSRetrivalSQL($data, &$joins, &$where, $andOperation = false) {


### PR DESCRIPTION
Really small update. Sorting on yes/no didn't make too much sense in this context, so I changed the field to sort on the `order` column instead. This allows you to get a list of entries back where the box is ticked (e.g. a "Feature on the homepage" checkbox) but also sorted by the order in which they were featured. No need to cobble together a checkbox and order entries to achieve the same spunktionality.
